### PR TITLE
Adds build job to CI to ensure builds TypeScript to JS successfully.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ version: 2.1
 workflows:
   main:
     jobs:
+      - build:
+          version: 12
+          name: "Build (Node 12)"
       - lint:
           version: 12
           name: "Lint (Node 12)"
@@ -17,6 +20,20 @@ workflows:
           name: "Integration (Node 12)"
 
 jobs:
+  build:
+    parameters:
+      version:
+        type: integer
+    docker:
+      - image: circleci/node:<< parameters.version >>
+    steps:
+      - checkout
+      - run:
+          name: "Build (Node << parameters.version >>)"
+          command: |
+            npm install
+            npm run build
+
   lint:
     parameters:
       version:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Since our tests run in TypeScript, we don't currently have validation it "builds" in CI.

This adds a job for that.

We may eventually want some tests that build and run in JS, as an example of the JS API's and general smoke test that is all working as expected. In which case, build could be a step in those jobs and wouldn't need to be separate.
