### PR TITLE
NODE-2239: Adding Keep Alive to HTTP Request Configuration

### DIFF
--- a/src/client/base-client.ts
+++ b/src/client/base-client.ts
@@ -85,7 +85,11 @@ export abstract class BaseClient<T> {
         BaseClient.getPackageVersion()
       )
 
+
+      const agentKeepAlive = new https.Agent({keepAlive:true})
+
       const options: RequestOptions = {
+        agent: agentKeepAlive,
         method: HTTP_METHOD,
         setHost: false, // Valid Node 9+, defaults true. Manually set header for Node 8+.
         host: sendOptions.host,


### PR DESCRIPTION
## Proposed Release Notes
- Base client will make HTTP requests asking that keep alive be kept on

## Links

## Details
- Being :bold: and _not_ creating a test for this.  During our previous keep alive research most sources indicated it's a pretty standard configuration option these days, and testing for whether a connection's using keep alive or not requiring standing up a test http server, and it's very often the integration tests with http servers that flake out. If this is too :bold: don't hesitate to keep me :accountable: accountable. 