### PR TITLE
Adds recommended strategy handler to pass to client.send() calls.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -214,6 +220,20 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -229,6 +249,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cli-cursor": {
@@ -295,6 +321,15 @@
       "dev": true,
       "requires": {
         "ms": "^2.1.1"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -591,6 +626,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -793,6 +834,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -874,6 +921,20 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.0.tgz",
+      "integrity": "sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.0",
+        "propagate": "^2.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -958,6 +1019,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -968,6 +1035,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "punycode": {
@@ -1314,6 +1387,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typescript": {
       "version": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "lint": "eslint 'index.ts' 'src/**' 'tests/**'",
     "prepare": "npm run build",
-    "unit": "ts-node ./node_modules/.bin/tape tests/unit/**/*.tap.ts",
+    "unit": "ts-node ./node_modules/.bin/tape tests/unit/*.tap.ts tests/unit/**/*.tap.ts",
     "integration": "ts-node ./node_modules/.bin/tape tests/integration/**/*.tap.ts",
     "test": "npm run build && npm run unit && npm run integration"
   },
@@ -29,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "eslint": "^5.14.1",
+    "nock": "^11.7.0",
     "semver": "^6.3.0",
     "tape": "^4.10.1",
     "ts-node": "^8.0.2",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,8 @@
 import * as metrics from './metrics'
+import * as spans from './spans'
 
-export { metrics }
+export { metrics, spans }
 
 export { RequestResponseError } from './base-client'
 export * from './response-parser'
+export * from './recommended-strategy'

--- a/src/client/metrics/batch.ts
+++ b/src/client/metrics/batch.ts
@@ -60,6 +60,39 @@ export class MetricBatch implements MetricBatchPayload {
     return this.metrics.length
   }
 
+  public split(): MetricBatch[] {
+    if (this.metrics.length === 0) {
+      return []
+    }
+
+    if (this.metrics.length === 1) {
+      const metrics = [this.metrics[0]]
+      const batch = MetricBatch.createNew(this.common, metrics)
+
+      return [batch]
+    }
+
+    const midpoint = Math.floor(this.metrics.length / 2)
+    const leftMetrics = this.metrics.slice(0, midpoint)
+    const rightMetrics = this.metrics.slice(midpoint)
+
+    const leftBatch = MetricBatch.createNew(this.common, leftMetrics)
+    const rightBatch = MetricBatch.createNew(this.common, rightMetrics)
+
+    return [leftBatch, rightBatch]
+  }
+
+  private static createNew(common: CommonMetricData, metrics: Metric[]): MetricBatch {
+    const batch = new MetricBatch(
+      common && common.attributes,
+      common && common.timestamp,
+      common &&  common['interval.ms'],
+      metrics
+    )
+
+    return batch
+  }
+
   public computeInterval(endTime: number): this {
     this.common['interval.ms'] = endTime - this.common.timestamp
     return this

--- a/src/client/recommended-strategy.ts
+++ b/src/client/recommended-strategy.ts
@@ -1,0 +1,316 @@
+import { IncomingMessage } from 'http'
+
+import { RequestData, SendCallback } from './base-client'
+import { parseResponse, RecommendedAction } from './response-parser'
+import { MetricBatch } from './metrics'
+import { SpanBatch } from './spans'
+
+const RETRY_FACTOR = 1
+const MAX_RETRIES = 10
+const BACKOFF_MAX_INTERVAL = 16
+
+interface Callback {
+  (finalError?: Error, finalAction?: RecommendedAction): void
+}
+
+export type Batch = MetricBatch | SpanBatch
+
+export interface RecommendedStrategyOptions {
+  /**
+   * Factor in seconds by which retry intervals are calculated.
+   * A 408 retry will retry exactly by the value. Backoff retries will
+   * exponentially increase time of next backoff using this value as the base.
+   * For example: a value of 1 (one second) will retry similar to: [1, 2, 4, 8, 16, ...]
+   */
+  retryFactor?: number
+  /**
+   * Maximum number of retries before failing and discarding data.
+   * All retries, regardless of type (retry-after, backoff, etc.),
+   * will count towards this maximum.
+   * For example: a 5 retry maximum when using expontential backoff will retry
+   * similar to [1, 2, 4, 8, 16] and then stop retrying and discard data.
+   */
+  maxRetries?: number
+  /**
+   * Maximum backoff retry interval in seconds.
+   * For example: 1s factor with 16s maximum will
+   * retry similar to: [1, 2, 4, 8, 16, 16, 16, ...]
+   */
+  backoffMaxInterval?: number
+}
+
+/**
+ * Creates a recommended strategy response handling function for
+ * Metric and Span clients that will invoke the provided
+ * callback upon completion.
+ * @param callback
+ */
+export function createRecommendedStrategyHandler<T extends Batch>(
+  options?: RecommendedStrategyOptions,
+  callback?: Callback
+): SendCallback<T> {
+  return createdRecommendedStrategyHandler
+
+  function createdRecommendedStrategyHandler(
+    error: Error,
+    response: IncomingMessage,
+    body: string,
+    requestData: RequestData<T>
+  ): void {
+    return recommendedStrategyHandler(
+      error,
+      response,
+      body,
+      requestData,
+      options,
+      callback
+    )
+  }
+}
+
+/**
+ * Recommended strategy response handling function for Metric and Span clients.
+ * Typically based to the callback argument for Metric and Span clients.
+ * May be invoked manually.
+ * @param error
+ * @param response
+ * @param body
+ * @param requestData
+ * @param options Optional options that can be manually provided to the function.
+ * @param callback Optional callback that can be manually provided to the function.
+ */
+// eslint-disable-next-line max-params
+export function recommendedStrategyHandler<T extends Batch>(
+  error: Error,
+  response: IncomingMessage,
+  body: string,
+  requestData: RequestData<T>,
+  options?: RecommendedStrategyOptions,
+  callback?: Callback
+): void {
+  options = options || {}
+  options.retryFactor = options.retryFactor || RETRY_FACTOR
+  options.maxRetries = options.maxRetries || MAX_RETRIES
+  options.backoffMaxInterval = options.backoffMaxInterval || BACKOFF_MAX_INTERVAL
+
+
+  if (response) {
+    requestData.client.logger.debug('Response status: ', response.statusCode)
+  }
+
+  const parsedResponse = parseResponse(error, response)
+  if (parsedResponse.error) {
+    requestData.client.logger.debug('Encountered error: ', parsedResponse.error)
+  }
+
+  const recommendedAction = parsedResponse.recommendedAction
+
+  switch (recommendedAction) {
+    case RecommendedAction.Success: {
+      return success(requestData, callback)
+    }
+
+    case RecommendedAction.Discard: {
+      return dropData(requestData, parsedResponse.error, callback)
+    }
+
+    case RecommendedAction.Retry: {
+      return retry(requestData, options, callback)
+    }
+
+    case RecommendedAction.SplitRetry: {
+      return splitAndRetry(requestData, options, callback)
+    }
+
+    case RecommendedAction.RetryAfter: {
+      return retryAfter(parsedResponse.retryAfterMs, requestData, options, callback)
+    }
+
+    case RecommendedAction.Backoff: {
+      return retryWithBackoff(requestData, parsedResponse.error, options, callback)
+    }
+
+    default: {
+      const unexpectedError =
+        new Error(`Unexpected action: ${RecommendedAction[recommendedAction]}`)
+
+      requestData.client.logger.error(unexpectedError.message)
+      return dropData(requestData, unexpectedError, callback)
+    }
+  }
+}
+
+function success<T extends Batch>(requestData: RequestData<T>, cb: Callback): void {
+  const { client, originalData } = requestData
+
+  const dataCount = originalData.getBatchSize()
+  client.logger.debug(`Successfully sent ${dataCount} data points.`)
+
+  if (cb) {
+    setImmediate(cb, null, RecommendedAction.Success)
+  }
+}
+
+function dropData<T extends Batch>(
+  requestData: RequestData<T>,
+  error: Error,
+  cb: Callback
+): void {
+  const { client, originalData } = requestData
+
+  const discardedDataCount = originalData.getBatchSize()
+
+  client.logger.error(
+    `Send failed. Discarding ${discardedDataCount} data points.`
+  )
+
+  if (cb) {
+    setImmediate(cb, error, RecommendedAction.Discard)
+  }
+}
+
+function retry<T extends Batch>(
+  requestData: RequestData<T>,
+  options: RecommendedStrategyOptions,
+  cb: Callback
+): void {
+  const { client, originalData } = requestData
+
+  const retryCount = requestData.retryCount || 1
+
+  if (retryCount > options.maxRetries) {
+    client.logger.info('Maximum retries reached.')
+    return dropData(requestData, null, cb)
+  }
+
+  const retryMs = options.retryFactor * 1000
+  client.logger.info(`Send failed. Retrying in ${retryMs}ms.`)
+
+  setTimeout((): void => {
+    const handler = createRetryHandler(retryCount, options, cb)
+    client.send(originalData, handler)
+  }, retryMs)
+}
+
+function splitAndRetry<T extends Batch>(
+  requestData: RequestData<T>,
+  options: RecommendedStrategyOptions,
+  cb: Callback
+): void {
+  const { client, originalData } = requestData
+
+  const retryCount = requestData.retryCount || 1
+
+  if (retryCount > options.maxRetries) {
+    client.logger.info('Maximum retries reached.')
+    return dropData(requestData, null, cb)
+  }
+
+  const retryMs = options.retryFactor * 1000
+
+  client.logger.info(`Batch size too large, splitting and retrying in ${retryMs}ms.`)
+  const batches = originalData.split()
+
+  const batchCount = batches.length
+
+  setTimeout((): void => {
+    for (let i = 0; i < batchCount; i++) {
+      const smallBatch: T = batches[0] as T
+
+      const handler = createRetryHandler(retryCount, options, onAllBatchesHandled)
+      client.send(smallBatch, handler)
+    }
+  }, retryMs)
+
+  let sentBatches = 0
+  let lastError: Error = null
+  let hasDiscard = false
+  function onAllBatchesHandled(finalError: Error, finalAction: RecommendedAction): void {
+    lastError = finalError || lastError
+
+    if (finalAction === RecommendedAction.Discard) {
+      hasDiscard = true
+    }
+
+    sentBatches++
+
+    if (sentBatches >= batchCount) {
+      const action = hasDiscard ? RecommendedAction.Discard : RecommendedAction.Success
+
+      cb(lastError, action)
+    }
+  }
+}
+
+function retryAfter<T extends Batch>(
+  retryAfterMs: number,
+  requestData: RequestData<T>,
+  options: RecommendedStrategyOptions,
+  cb: Callback
+): void {
+  const { client, originalData } = requestData
+
+  const retryCount = requestData.retryCount || 1
+
+  if (retryCount > options.maxRetries) {
+    client.logger.info('Maximum retries reached.')
+    return dropData(requestData, null, cb)
+  }
+
+  client.logger.error(
+    `Send failed. Retrying in ${retryAfterMs}ms.`
+  )
+
+  setTimeout((): void => {
+    const handler = createRetryHandler(retryCount, options, cb)
+    client.send(originalData, handler)
+  }, retryAfterMs)
+}
+
+function retryWithBackoff<T extends Batch>(
+  requestData: RequestData<T>,
+  error: Error,
+  options: RecommendedStrategyOptions,
+  cb: Callback
+): void {
+  const { client, originalData } = requestData
+
+  const retryCount = requestData.retryCount || 1
+
+  if (retryCount > options.maxRetries) {
+    client.logger.info('Maximum retries reached.')
+    return dropData(requestData, error, cb)
+  }
+
+  // If backoff occurs after other retry-types, it will schedule at the interval
+  // as if it had been doing backoff retries the whole time.
+  const newInterval = options.retryFactor * Math.pow(2, (retryCount - 1))
+  const retryMs = Math.min(options.backoffMaxInterval, newInterval) * 1000
+
+  client.logger.info(
+    `Send failed. Retrying with backoff in ${retryMs} milliseconds.`
+  )
+
+  setTimeout((): void => {
+    const handler = createRetryHandler(retryCount, options, cb)
+    client.send(originalData, handler)
+  }, retryMs)
+}
+
+function createRetryHandler<T extends Batch>(
+  retryCount: number,
+  options: RecommendedStrategyOptions,
+  cb: Callback
+): SendCallback<T> {
+  return retryHandler
+
+  function retryHandler(
+    err: Error,
+    res: IncomingMessage,
+    body: string,
+    retryData: RequestData<T>
+  ): void {
+    retryData.retryCount = retryCount + 1
+    return recommendedStrategyHandler(err, res, body, retryData, options, cb)
+  }
+}

--- a/src/client/spans/batch.ts
+++ b/src/client/spans/batch.ts
@@ -66,4 +66,35 @@ export class SpanBatch implements SpanBatchPayload {
       Math.random() * ((max + 1) - min)
     ) + min
   }
+
+  public getBatchSize(): number {
+    return this.spans.length
+  }
+
+  public split(): SpanBatch[] {
+    if (this.spans.length === 0) {
+      return []
+    }
+
+    if (this.spans.length === 1) {
+      const spans = [this.spans[0]]
+      const batch = SpanBatch.createNew(this.common, spans)
+
+      return [batch]
+    }
+
+    const midpoint = Math.floor(this.spans.length / 2)
+    const leftSpans = this.spans.slice(0, midpoint)
+    const rightSpans = this.spans.slice(midpoint)
+
+    const leftBatch = SpanBatch.createNew(this.common, leftSpans)
+    const rightBatch = SpanBatch.createNew(this.common, rightSpans)
+
+    return [leftBatch, rightBatch]
+  }
+
+  private static createNew(common: CommonSpanData, spans: SpanData[]): SpanBatch {
+    const batch = new SpanBatch(common && common.attributes, spans)
+    return batch
+  }
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -7,21 +7,15 @@ export interface LoggerFunction {
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export interface Logger {
-  fatal: LoggerFunction
   error: LoggerFunction
-  warn: LoggerFunction
   info: LoggerFunction
   debug: LoggerFunction
-  trace: LoggerFunction
 }
 
 const _noOp = (): void => {}
 
 export class NoOpLogger implements Logger {
-  public fatal = _noOp
   public error = _noOp
-  public warn = _noOp
   public info = _noOp
   public debug = _noOp
-  public trace = _noOp
 }

--- a/tests/integration/recommended-strategy.tap.ts
+++ b/tests/integration/recommended-strategy.tap.ts
@@ -1,0 +1,784 @@
+import test from 'tape'
+import nock from 'nock'
+
+import {
+  recommendedStrategyHandler,
+  createRecommendedStrategyHandler,
+  metrics,
+  RecommendedAction,
+  RecommendedStrategyOptions
+} from '../../src/client'
+
+const FAKE_HOST = 'fakehost.newrelic.com'
+const METRIC_PATH = '/metric/v1'
+
+test('Should handle success cases', (t): void => {
+  for (let i = 200; i < 300; i++) {
+    t.test(`Should be success on ${i} status code`, createSuccessTest(i))
+  }
+
+  function createSuccessTest(statusCode: number): test.TestCase {
+    return successTestCase
+
+    function successTestCase(t: test.Test): void {
+      nock.disableNetConnect()
+
+      mockEndpoint(METRIC_PATH).reply(statusCode)
+      const metricClient = createMetricClient()
+
+      const batch = new metrics.MetricBatch()
+      batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+      const handler = createRecommendedStrategyHandler(null, assertSuccess)
+      metricClient.send(batch, handler)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Success,
+          `Should have ended with Success but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    }
+  }
+})
+
+test('Should drop data on 400', (t): void => {
+  const dropCodes = [400, 401, 403, 404, 405, 409, 410, 411]
+
+  dropCodes.forEach((statusCode): void => {
+    t.test(`Should drop data on ${statusCode} status code`, createDiscardTest(statusCode))
+  })
+
+  function createDiscardTest(statusCode: number): test.TestCase {
+    return discardTestCase
+
+    function discardTestCase(t: test.Test): void {
+      nock.disableNetConnect()
+
+      mockEndpoint(METRIC_PATH).reply(statusCode)
+      const metricClient = createMetricClient()
+
+      const batch = new metrics.MetricBatch()
+      batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+      const handler = createRecommendedStrategyHandler(null, assertSuccess)
+      metricClient.send(batch, handler)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    }
+  }
+})
+
+test('Should retry on 408', (t): void => {
+  t.test('Should return Success on 202 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(408)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint = mockEndpoint(METRIC_PATH).reply(202)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint.isDone(), 'Should have made retry request.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Success,
+          `Should have ended with Success but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Discard on 404 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(408)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint = mockEndpoint(METRIC_PATH).reply(404)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint.isDone(), 'Should have made retry request.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should retry on 404 retry, Success on 200 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(408)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint = mockEndpoint(METRIC_PATH).reply(408)
+      const successEndpoint = mockEndpoint(METRIC_PATH).reply(200)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint.isDone(), 'Should have made first retry request.')
+        t.ok(successEndpoint.isDone(), 'Should have made second retry request.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Success,
+          `Should have ended with Success but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Discard on max retries', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(408)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+
+      // Mock each intead of persist so any extra tries would error
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(408)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(408)
+      const retryEndpoint3 = mockEndpoint(METRIC_PATH).reply(408)
+
+      // constrain things a bit so test runs faster
+      const options: RecommendedStrategyOptions = {
+        maxRetries: 3
+      }
+
+      recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request 1.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request 2.')
+        t.ok(retryEndpoint3.isDone(), 'Should have made retry request 3.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+})
+
+test('Should split and retry on 413', (t): void => {
+  t.test('Should return Success when both succeed', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(413)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric1', type: metrics.MetricType.Count, value: 2})
+    batch.addMetric({name: 'MyMetric2', type: metrics.MetricType.Count, value: 4})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(200)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(200)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request for first half.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request for second half.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Success,
+          `Should have ended with Success but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return discard when both discard', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(413)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric1', type: metrics.MetricType.Count, value: 2})
+    batch.addMetric({name: 'MyMetric2', type: metrics.MetricType.Count, value: 4})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(400)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(404)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request for first half.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request for second half.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return last seen error, when both error', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(413)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric1', type: metrics.MetricType.Count, value: 2})
+    batch.addMetric({name: 'MyMetric2', type: metrics.MetricType.Count, value: 4})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+
+      // Only let retry network error once
+      const options: RecommendedStrategyOptions = {
+        maxRetries: 1
+      }
+
+      recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.ok(finalError)
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const nockError = finalError as any
+        t.equal(nockError.statusCode, 404, 'Should be 404 error from nock.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return error when one errors', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(413)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric1', type: metrics.MetricType.Count, value: 2})
+    batch.addMetric({name: 'MyMetric2', type: metrics.MetricType.Count, value: 4})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(202)
+
+      // Only let retry network error once
+      const options: RecommendedStrategyOptions = {
+        maxRetries: 1
+      }
+
+      recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.ok(retryEndpoint1.isDone(), 'Should hade retry request for a half.')
+
+        t.ok(finalError)
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const nockError = finalError as any
+        t.equal(nockError.statusCode, 404, 'Should be 404 error from nock.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Discard on max retries', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(413)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric1', type: metrics.MetricType.Count, value: 2})
+    batch.addMetric({name: 'MyMetric2', type: metrics.MetricType.Count, value: 4})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+
+      // Mock each intead of persist so any extra tries would error.
+      // Each original split path will get 3 requests (since data can't be split further)
+      // for a total of 3 retry attempts per.
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(413)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(413)
+      const retryEndpoint3 = mockEndpoint(METRIC_PATH).reply(413)
+      const retryEndpoint4 = mockEndpoint(METRIC_PATH).reply(413)
+      const retryEndpoint5 = mockEndpoint(METRIC_PATH).reply(413)
+      const retryEndpoint6 = mockEndpoint(METRIC_PATH).reply(413)
+
+      const options: RecommendedStrategyOptions = {
+        maxRetries: 3
+      }
+
+      recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should hade retry request for a half.')
+        t.ok(retryEndpoint2.isDone(), 'Should hade retry request for a half.')
+        t.ok(retryEndpoint3.isDone(), 'Should hade retry request for a half.')
+        t.ok(retryEndpoint4.isDone(), 'Should hade retry request for a half.')
+        t.ok(retryEndpoint5.isDone(), 'Should hade retry request for a half.')
+        t.ok(retryEndpoint6.isDone(), 'Should hade retry request for a half.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+})
+
+test('Should retry-after on 429', (t): void => {
+  t.test('Should return Discard on 404 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH)
+      .reply(429)
+      .defaultReplyHeaders({'retry-after': '2'})
+
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint = mockEndpoint(METRIC_PATH).reply(404)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint.isDone(), 'Should have made retry request.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Success on 202 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH)
+      .reply(429)
+      .defaultReplyHeaders({'retry-after': '2'})
+
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint = mockEndpoint(METRIC_PATH).reply(202)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint.isDone(), 'Should have made retry request.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Success,
+          `Should have ended with Success but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Discard on max retries', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH)
+      .reply(429)
+      .defaultReplyHeaders({'retry-after': '1'})
+
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+
+      // Mock each intead of persist so any extra tries would error
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH)
+        .reply(429)
+        .defaultReplyHeaders({'retry-after': '2'})
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH)
+        .reply(429)
+        .defaultReplyHeaders({'retry-after': '2'})
+      const retryEndpoint3 = mockEndpoint(METRIC_PATH)
+        .reply(429)
+        .defaultReplyHeaders({'retry-after': '2'})
+
+      // constrain things a bit so test runs faster
+      const options: RecommendedStrategyOptions = {
+        maxRetries: 3
+      }
+
+      recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request 1.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request 2.')
+        t.ok(retryEndpoint3.isDone(), 'Should have made retry request 3.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+})
+
+test('Should backoff-retry on 300', (t): void => {
+  t.test('Should return Discard on 400 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(300)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint3 = mockEndpoint(METRIC_PATH).reply(400)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request 1.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request 2.')
+        t.ok(retryEndpoint3.isDone(), 'Should have made retry request 3.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Success on 202 retry', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(300)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint3 = mockEndpoint(METRIC_PATH).reply(202)
+
+      recommendedStrategyHandler(err, res, body, requestData, null, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request 1.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request 2.')
+        t.ok(retryEndpoint3.isDone(), 'Should have made retry request 3.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Success,
+          `Should have ended with Success but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+
+  t.test('Should return Discard on max retries', (t): void => {
+    nock.disableNetConnect()
+
+    const initialEndpoint = mockEndpoint(METRIC_PATH).reply(300)
+    const metricClient = createMetricClient()
+
+    const batch = new metrics.MetricBatch()
+    batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+    metricClient.send(batch, (err, res, body, requestData): void => {
+      t.error(err)
+
+      t.ok(initialEndpoint.isDone(), 'Should have made initial request.')
+
+      // Mock each intead of persist so any extra tries would error
+      const retryEndpoint1 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint2 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint3 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint4 = mockEndpoint(METRIC_PATH).reply(300)
+      const retryEndpoint5 = mockEndpoint(METRIC_PATH).reply(300)
+
+      // constrain things a bit so test runs faster
+      const options: RecommendedStrategyOptions = {
+        retryFactor: 1,
+        maxRetries: 5,
+        backoffMaxInterval: 2
+      }
+
+      recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+      function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+        t.error(finalError)
+
+        t.ok(retryEndpoint1.isDone(), 'Should have made retry request 1.')
+        t.ok(retryEndpoint2.isDone(), 'Should have made retry request 2.')
+        t.ok(retryEndpoint3.isDone(), 'Should have made retry request 3.')
+        t.ok(retryEndpoint4.isDone(), 'Should have made retry request 4.')
+        t.ok(retryEndpoint5.isDone(), 'Should have made retry request 5.')
+
+        t.equal(
+          finalAction,
+          RecommendedAction.Discard,
+          `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+        )
+
+        tearDown()
+        t.end()
+      }
+    })
+  })
+})
+
+test('Should return Discard on max retries across retry types', (t): void => {
+  nock.disableNetConnect()
+
+  const initialBackoffEndpoint = mockEndpoint(METRIC_PATH).reply(300)
+  const metricClient = createMetricClient()
+
+  const batch = new metrics.MetricBatch()
+  batch.addMetric({name: 'MyMetric', type: metrics.MetricType.Count, value: 2})
+
+  metricClient.send(batch, (err, res, body, requestData): void => {
+    t.error(err)
+
+    t.ok(initialBackoffEndpoint.isDone(), 'Should have made initial request.')
+
+    // Mock each intead of persist so any extra tries would error
+    const retryAfterEndpoint = mockEndpoint(METRIC_PATH)
+      .reply(429)
+      .defaultReplyHeaders({'retry-after': '2'})
+
+    // Only one piece of data so won't be able to split, will be 1 request
+    const splitRetryEndpoint = mockEndpoint(METRIC_PATH).reply(413)
+    const retryEndpoint3 = mockEndpoint(METRIC_PATH).reply(408)
+
+    // constrain things a bit so test runs faster
+    const options: RecommendedStrategyOptions = {
+      maxRetries: 3
+    }
+
+    recommendedStrategyHandler(err, res, body, requestData, options, assertSuccess)
+
+    function assertSuccess(finalError: Error, finalAction: RecommendedAction): void {
+      t.error(finalError)
+
+      t.ok(retryAfterEndpoint.isDone(), 'Should have made retry request 1.')
+      t.ok(splitRetryEndpoint.isDone(), 'Should have made retry request 2.')
+      t.ok(retryEndpoint3.isDone(), 'Should have made retry request 3.')
+
+      t.equal(
+        finalAction,
+        RecommendedAction.Discard,
+        `Should have ended with Discard but got ${RecommendedAction[finalAction]}`
+      )
+
+      tearDown()
+      t.end()
+    }
+  })
+})
+
+function mockEndpoint(path: string): nock.Interceptor {
+  return nock(`https://${FAKE_HOST}`).post(path)
+}
+
+function createMetricClient(): metrics.MetricClient {
+  const options: metrics.MetricClientOptions = {
+    apiKey: 'some key',
+    host: FAKE_HOST
+  }
+
+  const metricClient = new metrics.MetricClient(options)
+  return metricClient
+}
+
+function tearDown(): void {
+  if (!nock.isDone()) {
+    // eslint-disable-next-line no-console
+    console.error('Cleaning pending mocks: %j', nock.pendingMocks())
+    nock.cleanAll()
+  }
+
+  nock.enableNetConnect()
+}

--- a/tests/unit/base-client.tap.ts
+++ b/tests/unit/base-client.tap.ts
@@ -1,12 +1,12 @@
 import test from 'tape'
 import semver from 'semver'
-import {BaseClient, SendDataCallback} from '../../src/client/base-client'
+import {BaseClient, SendCallback} from '../../src/client/base-client'
 
 class MockBatch {
 }
 
 class MockClient extends BaseClient<MockBatch> {
-  public send(data: MockBatch, callback: SendDataCallback): void {
+  public send(data: MockBatch, callback: SendCallback<MockBatch>): void {
     data
     callback
   }

--- a/tests/unit/response-parser.tap.ts
+++ b/tests/unit/response-parser.tap.ts
@@ -1,0 +1,120 @@
+import test from 'tape'
+import { IncomingMessage } from 'http'
+import { Socket } from 'net'
+
+import { parseResponse, RecommendedAction, RequestResponseError } from '../../src/client'
+
+test('parseResponse()', (t): void => {
+  t.test('Should return Success for 200 status codes', (t): void => {
+    for (let i = 200; i < 300; i++) {
+      verifyParsedResponse(t, i, RecommendedAction.Success)
+    }
+
+    t.end()
+  })
+
+  t.test('Should return Discard for specific status codes', (t): void => {
+    const dropCodes = [400, 401, 403, 404, 405, 409, 410, 411]
+
+    dropCodes.forEach((statusCode): void => {
+      verifyParsedResponse(t, statusCode, RecommendedAction.Discard)
+    })
+
+    t.end()
+  })
+
+  t.test('Should return Retry for 408 status codes', (t): void => {
+    verifyParsedResponse(t, 408, RecommendedAction.Retry)
+    t.end()
+  })
+
+  t.test('Should return SplitRetry for 413 status codes', (t): void => {
+    verifyParsedResponse(t, 413, RecommendedAction.SplitRetry)
+    t.end()
+  })
+
+  t.test('Should return RetryAfter for 429 status codes', (t): void => {
+    const expectedRetry = 10000
+
+    const response = createResponse(429)
+    response.headers['retry-after'] = (expectedRetry / 1000).toString()
+
+    const parsedResponse = parseResponse(null, response)
+
+    t.equal(
+      parsedResponse.recommendedAction,
+      RecommendedAction.RetryAfter,
+      'Status code 429 should result in RetryAfter'
+    )
+
+    t.equal(parsedResponse.retryAfterMs, expectedRetry)
+
+    t.end()
+  })
+
+  t.test('Should return Backoff for unknown status codes', (t): void => {
+    const unknownCodes = [300, 402, 500]
+    unknownCodes.forEach((statusCode): void => {
+      verifyParsedResponse(t, statusCode, RecommendedAction.Backoff)
+    })
+
+    t.end()
+  })
+
+  t.test('Should return Discard for unexpected app error', (t): void => {
+    const error = new Error()
+
+    const parsedResponse = parseResponse(error, null)
+
+    t.equal(parsedResponse.error, error)
+
+    t.equal(
+      parsedResponse.recommendedAction,
+      RecommendedAction.Discard,
+      'Unexpected error should result in Discard'
+    )
+
+    t.end()
+  })
+
+  t.test('Should return Backoff for network error and inner error', (t): void => {
+    const innerError = new Error('Inner Fail')
+    const outerError = new RequestResponseError('Outer Fail', innerError)
+
+    const parsedResponse = parseResponse(outerError, null)
+
+    t.equal(parsedResponse.error, innerError)
+
+    t.equal(
+      parsedResponse.recommendedAction,
+      RecommendedAction.Backoff,
+      'Network error should result in Backoff'
+    )
+
+    t.end()
+  })
+})
+
+function verifyParsedResponse(
+  t: test.Test,
+  statusCode: number,
+  recommendedAction: RecommendedAction
+): void {
+  const response = createResponse(statusCode)
+
+  const parsedResponse = parseResponse(null, response)
+  t.equal(
+    parsedResponse.recommendedAction,
+    recommendedAction,
+    `Status code ${statusCode} should result in ${RecommendedAction[recommendedAction]}`
+  )
+
+  t.notOk(parsedResponse.error)
+}
+
+function createResponse(statusCode: number): IncomingMessage {
+  const response = new IncomingMessage(new Socket())
+  response.statusCode = statusCode
+
+  return response
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Allows user to leverage pre-defined "recommended strategy" logic for handling responses to sending batches to the server. This is done via an exported function to allow for flexibility as well as keeping a functional style.

Adds recommended strategy handling per spec here: https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#response-codes

The spec doesn't specifically call out maximums for all retry types but I implemented that per conversation around existing SDK's and my own concerns. Currently, all retries per origination path count towards the maximum regardless of retry type.

### Standard Usage

Just let NR handle-it, take the defaults:

```js
metricClient.send(batch, recommendedStrategyHandler)
```

Create handler with options:
```js
const handler = createRecommendedStrategyHandler({maxRetries: 2})
metricClient.send(batch, handler)
```

Create handler with callback:

```js
function sendFinishedHandler(finalError: Error, finalAction: RecommendedAction): void {
  if (finalAction === RecommendedAction.Discard) {
    log.error('Send didnt fully succeed. I am sad', finalError)
  }
}

const handler = createRecommendedStrategyHandler({maxRetries: 2}, sendFinishedHandler)
metricClient.send(batch, handler)
```

### Advanced Usage

Custom logic / manual invocation:

```js
function handleSend(
  error: Error, 
  response: IncomingMessage, 
  body: string, 
  requestData: RequestData
): void {
  if (response.statusCode === 418) {
    log.info('Im a teapot')
    return
  }

  return recommendedStrategyHandler(error, response, body, requestData)
}

metricClient.send(batch, handleSend)
```