### PR TITLE
Moves LIMIT off of batches which currently need to serialize cleanly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "lint": "eslint 'index.ts' 'src/**' 'tests/**'",
     "prepare": "npm run build",
-    "unit": "ts-node ./node_modules/.bin/tape tests/unit/**/*.tap.ts",
+    "unit": "ts-node ./node_modules/.bin/tape tests/unit/*.tap.ts tests/unit/**/*.tap.ts",
     "integration": "ts-node ./node_modules/.bin/tape tests/integration/**/*.tap.ts",
     "test": "npm run build && npm run unit && npm run integration"
   },

--- a/src/client/metrics/batch.ts
+++ b/src/client/metrics/batch.ts
@@ -16,10 +16,11 @@ interface MetricBatchPayload {
   metrics: Metric[]
 }
 
+export const LIMIT = 2000
+
 export class MetricBatch implements MetricBatchPayload {
   public common?: CommonMetricData
 
-  protected readonly LIMIT = 2000
   public metrics: Metric[]
 
   public constructor(
@@ -48,8 +49,8 @@ export class MetricBatch implements MetricBatchPayload {
 
     this.metrics = metrics || []
 
-    if (this.metrics.length > this.LIMIT) {
-      const remnant = this.metrics.splice(this.LIMIT)
+    if (this.metrics.length > LIMIT) {
+      const remnant = this.metrics.splice(LIMIT)
       for (const idAndRemnant of remnant.entries()) {
         this.addMetric(idAndRemnant[1])
       }
@@ -68,7 +69,7 @@ export class MetricBatch implements MetricBatchPayload {
   public addMetric(metric: Metric): MetricBatch {
     this.metrics.push(metric)
     const len = this.metrics.length
-    if (len > this.LIMIT) {
+    if (len > LIMIT) {
       const indexToDrop = this.getRandomInt(0, len - 1)
       const droppedMetric = this.metrics[indexToDrop]
       this.metrics[indexToDrop] = this.metrics[len - 1]

--- a/src/client/spans/batch.ts
+++ b/src/client/spans/batch.ts
@@ -14,8 +14,9 @@ interface SpanBatchPayload {
   common?: CommonSpanData
 }
 
+export const LIMIT = 2000
+
 export class SpanBatch implements SpanBatchPayload {
-  protected readonly LIMIT = 2000
   public common?: CommonSpanData
   public spans: Span[]
 
@@ -32,11 +33,11 @@ export class SpanBatch implements SpanBatchPayload {
 
     this.spans = spans || []
     // if the client programmer passed us an array that's
-    // too big, keep the first `this.LIMIT` items and
+    // too big, keep the first `LIMIT` items and
     // then use addSpan to add the rest (making the later
     // items subject to the adaptive sampling)
-    if (this.spans.length > this.LIMIT) {
-      const remnant = this.spans.splice(this.LIMIT)
+    if (this.spans.length > LIMIT) {
+      const remnant = this.spans.splice(LIMIT)
       this.addSpan(...remnant)
     }
   }
@@ -46,7 +47,7 @@ export class SpanBatch implements SpanBatchPayload {
       this.spans.push(span)
       const len = this.spans.length
       // keep spans array at its limited value
-      if (len > this.LIMIT) {
+      if (len > LIMIT) {
         const indexToDrop = this.getRandomInt(0, len - 1)
         const droppedSpan = this.spans[indexToDrop]
         this.spans[indexToDrop] = this.spans[len - 1]

--- a/tests/unit/limits.tap.ts
+++ b/tests/unit/limits.tap.ts
@@ -3,8 +3,7 @@ import uuidv4 from 'uuid/v4'
 
 import {
   SummaryMetric,
-  MetricBatch,
-  Metric
+  MetricBatch
 } from '../../src/client/metrics'
 
 import {
@@ -12,34 +11,17 @@ import {
   SpanBatch,
 } from '../../src/client/spans'
 
-class MockMetricBatch extends MetricBatch {
-  public mockGetMetrics(): Metric[] {
-    return this.metrics
-  }
-
-  public mockGetLimit(): number {
-    return this.LIMIT
-  }
-}
-
-class MockSpanBatch extends SpanBatch {
-  public mockGetSpans(): Span[] {
-    return this.spans
-  }
-
-  public mockGetLimit(): number {
-    return this.LIMIT
-  }
-}
+import {LIMIT as METRIC_LIMIT} from '../../src/client/metrics/batch'
+import {LIMIT as SPAN_LIMIT} from '../../src/client/spans/batch'
 
 test('test limits on batches', (t): void => {
   t.test('test metric limits', (t): void => {
-    const batch = new MockMetricBatch
-    t.ok(0 === batch.mockGetMetrics().length, 'new batch is empty')
+    const batch = new MetricBatch()
+    t.equal(batch.metrics.length, 0, 'new batch is empty')
 
     // get a big'old array of metrics for us to reuse
     let hugeMetrics: SummaryMetric[] = []
-    while (hugeMetrics.length < batch.mockGetLimit() + 10) {
+    while (hugeMetrics.length < METRIC_LIMIT + 10) {
       hugeMetrics.push(new SummaryMetric('foo'))
     }
 
@@ -48,27 +30,27 @@ test('test limits on batches', (t): void => {
       batch.addMetric(idMetrics[1])
     }
 
-    t.ok(
-      batch.mockGetLimit() === batch.mockGetMetrics().length,
-      'batch did not collect too many metrics'
-    )
+    t.equal(batch.metrics.length, METRIC_LIMIT, 'batch did not collect too many metrics')
 
     // try creating a new batch with too many metrics
-    const batch2 = new MockMetricBatch({ test: true }, Date.now(), 1000, hugeMetrics)
-    t.ok(
-      batch2.mockGetLimit() === batch2.mockGetMetrics().length,
+    const batch2 = new MetricBatch({ test: true }, Date.now(), 1000, hugeMetrics)
+
+    t.equal(
+      batch2.metrics.length,
+      METRIC_LIMIT,
       'batch did not keep too large metrics array'
     )
+
     t.end()
   })
 
   t.test('test span limits', (t): void => {
-    const batch = new MockSpanBatch
-    t.ok(0 === batch.mockGetSpans().length, 'new batch is empty')
+    const batch = new SpanBatch()
+    t.equal(batch.spans.length, 0, 'new batch is empty')
 
     // get a big'old array of metrics for us to reuse
     let hugeSpans: Span[] = []
-    while (hugeSpans.length < batch.mockGetLimit() + 10) {
+    while (hugeSpans.length < SPAN_LIMIT + 10) {
       hugeSpans.push({
         'id': uuidv4(),
         'trace.id': 'abc123',
@@ -86,17 +68,12 @@ test('test limits on batches', (t): void => {
       batch.addSpan(idSpans[1])
     }
 
-    t.ok(
-      batch.mockGetLimit() === batch.mockGetSpans().length,
-      'batch did not collect too many spans'
-    )
+    t.equal(batch.spans.length, SPAN_LIMIT, 'batch did not collect too many spans')
 
     // try creating a new batch with too many metrics
-    const batch2 = new MockSpanBatch({}, hugeSpans)
-    t.ok(
-      batch2.mockGetLimit() === batch2.mockGetSpans().length,
-      'batch did not keep too large span array'
-    )
+    const batch2 = new SpanBatch({}, hugeSpans)
+
+    t.equal(batch2.spans.length, SPAN_LIMIT, 'batch did not keep too large span array')
     t.end()
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

We don't yet send by interface, so the batches need to be able to serialize directly into what is sent. As such, had to move LIMIT off of the batch classes to avoid `NRIntegrationError` events on the server.
