### PR TITLE
Bump server integration log client test wait time

### DIFF
--- a/tests/server-integration/log-client.tap.ts
+++ b/tests/server-integration/log-client.tap.ts
@@ -6,7 +6,7 @@ import { OutgoingHttpHeaders, IncomingMessage } from 'http'
 import {Log, LogBatch, LogClient, LogClientOptions} from '../../src/telemetry/logs'
 
 
-const LOGGING_DELAY_MS = 1000
+const LOGGING_DELAY_MS = 1500
 
 const logConfig: LogClientOptions = {
   apiKey: process.env.TEST_API_KEY,


### PR DESCRIPTION
Bumps server integration log client test verification wait time to 1.5 seconds to avoid occasional server slowness.