### PR TITLE
Increase log-client integration test verification wait time to 3 seconds.

### DIFF
--- a/tests/server-integration/log-client.tap.ts
+++ b/tests/server-integration/log-client.tap.ts
@@ -6,7 +6,7 @@ import { OutgoingHttpHeaders, IncomingMessage } from 'http'
 import {Log, LogBatch, LogClient, LogClientOptions} from '../../src/telemetry/logs'
 
 
-const LOGGING_DELAY_MS = 2500
+const LOGGING_DELAY_MS = 2000
 
 const logConfig: LogClientOptions = {
   apiKey: process.env.TEST_API_KEY,

--- a/tests/server-integration/log-client.tap.ts
+++ b/tests/server-integration/log-client.tap.ts
@@ -6,7 +6,7 @@ import { OutgoingHttpHeaders, IncomingMessage } from 'http'
 import {Log, LogBatch, LogClient, LogClientOptions} from '../../src/telemetry/logs'
 
 
-const LOGGING_DELAY_MS = 2500
+const LOGGING_DELAY_MS = 3000
 
 const logConfig: LogClientOptions = {
   apiKey: process.env.TEST_API_KEY,

--- a/tests/server-integration/log-client.tap.ts
+++ b/tests/server-integration/log-client.tap.ts
@@ -6,7 +6,7 @@ import { OutgoingHttpHeaders, IncomingMessage } from 'http'
 import {Log, LogBatch, LogClient, LogClientOptions} from '../../src/telemetry/logs'
 
 
-const LOGGING_DELAY_MS = 2000
+const LOGGING_DELAY_MS = 2500
 
 const logConfig: LogClientOptions = {
   apiKey: process.env.TEST_API_KEY,

--- a/tests/server-integration/log-client.tap.ts
+++ b/tests/server-integration/log-client.tap.ts
@@ -6,7 +6,7 @@ import { OutgoingHttpHeaders, IncomingMessage } from 'http'
 import {Log, LogBatch, LogClient, LogClientOptions} from '../../src/telemetry/logs'
 
 
-const LOGGING_DELAY_MS = 1500
+const LOGGING_DELAY_MS = 2500
 
 const logConfig: LogClientOptions = {
   apiKey: process.env.TEST_API_KEY,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Increased wait time for log-client integration test verification to 3 seconds to mitigate intermittent test failures.
## Links
Closes: #55 
## Details
