### PR TITLE
feat: Add batchSize interface to logs batch

### DIFF
--- a/src/telemetry/logs/model.ts
+++ b/src/telemetry/logs/model.ts
@@ -42,4 +42,8 @@ export class LogBatch {
   public append(message: LogMessage): void {
     this.logs.push(message)
   }
+
+  public getBatchSize(): number {
+    return this.logs.length
+  }
 }


### PR DESCRIPTION
Our tests in our Azure integration check batch size for spans and events. This would be useful for logs also.

Signed-off-by: mrickard <maurice@mauricerickard.com>

