### PR TITLE
correct Event API hostname

### DIFF
--- a/src/telemetry/events/client.ts
+++ b/src/telemetry/events/client.ts
@@ -2,7 +2,7 @@ import { BaseClient, SendDataOptions, SendCallback, RequestData } from '../base-
 import { EventBatch } from './batch'
 import { Logger} from '../../common'
 
-const EVENT_HOST = 'insights-collector.nr-data.net'
+const EVENT_HOST = 'insights-collector.newrelic.com'
 const EVENT_PORT = 443
 const EVENT_PATH = '/v1/accounts/events'
 const INVALID_KEY_MESSAGE = 'A valid key must be provided for inserting events.'

--- a/tests/unit/events/client.tap.ts
+++ b/tests/unit/events/client.tap.ts
@@ -5,7 +5,7 @@ import { EventClient, EventClientOptions } from '../../../src/telemetry/events/c
 test('EventClient', (t): void => {
   t.test('Should use default host and port when not specified in constructor',
     (t): void => {
-      const EVENT_HOST = 'insights-collector.nr-data.net'
+      const EVENT_HOST = 'insights-collector.newrelic.com'
       const EVENT_PORT = 443
 
       const opts: EventClientOptions = {


### PR DESCRIPTION
insights-collector.nr-data.net does not resolve.

The correct hostname is insights-collector.newrelic.com, as per https://docs.newrelic.com/docs/telemetry-data-platform/ingest-apis/introduction-event-api/

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Correct New Relic endpoint for Event API

## Links

* https://docs.newrelic.com/docs/telemetry-data-platform/ingest-apis/introduction-event-api/

## Details

insights-collector.nr-data.net is not a resolvable hostname.

```
nslookup insights-collector.nr-data.net 1.1.1.1
Server:		1.1.1.1
Address:	1.1.1.1#53

Non-authoritative answer:
*** Can't find insights-collector.nr-data.net: No answer
```